### PR TITLE
👽 :feat: [PHM-118] #comment Redmine - 추가된 이슈유형 업데이트시 서버데이터 null 체크 - 24.…

### DIFF
--- a/src/main/java/com/arms/api/jira/jiraproject/service/JiraProjectImpl.java
+++ b/src/main/java/com/arms/api/jira/jiraproject/service/JiraProjectImpl.java
@@ -247,11 +247,21 @@ public class JiraProjectImpl extends TreeServiceImpl implements JiraProject {
     private JiraIssueTypeEntity 미등록_이슈_유형_저장_및_저장된_엔티티(지라이슈유형_데이터 이슈_유형) throws Exception {
         JiraIssueTypeEntity 저장할_이슈_유형 = new JiraIssueTypeEntity();
         // 공통
-        저장할_이슈_유형.setC_issue_type_id(이슈_유형.getId());
-        저장할_이슈_유형.setC_issue_type_name(이슈_유형.getName());
-        저장할_이슈_유형.setC_issue_type_url(이슈_유형.getSelf());
-        저장할_이슈_유형.setC_issue_type_desc(이슈_유형.getDescription());
-        저장할_이슈_유형.setC_desc(이슈_유형.getSubtask().toString()); //Boolean
+        if (이슈_유형.getId() != null) {
+            저장할_이슈_유형.setC_issue_type_id(이슈_유형.getId());
+        }
+        if (이슈_유형.getName() != null) {
+            저장할_이슈_유형.setC_issue_type_name(이슈_유형.getName());
+        }
+        if (이슈_유형.getSelf() != null) {
+            저장할_이슈_유형.setC_issue_type_url(이슈_유형.getSelf());
+        }
+        if (이슈_유형.getDescription() != null) {
+            저장할_이슈_유형.setC_issue_type_desc(이슈_유형.getDescription());
+        }
+        if (이슈_유형.getSubtask() != null) {
+            저장할_이슈_유형.setC_desc(이슈_유형.getSubtask().toString()); //Boolean
+        }
         if (이슈_유형.getName().equals("arms-requirement")) {
             저장할_이슈_유형.setC_check("true"); //기본값 false 설정
         } else {
@@ -259,8 +269,12 @@ public class JiraProjectImpl extends TreeServiceImpl implements JiraProject {
         }
         저장할_이슈_유형.setRef(TreeConstant.First_Node_CID);
         저장할_이슈_유형.setC_type(TreeConstant.Leaf_Node_TYPE);
-        저장할_이슈_유형.setC_etc(이슈_유형.getUntranslatedName());
-        저장할_이슈_유형.setC_contents(이슈_유형.getHierarchyLevel().toString()); //Integer
+        if (이슈_유형.getUntranslatedName() != null) {
+            저장할_이슈_유형.setC_etc(이슈_유형.getUntranslatedName());
+        }
+        if (이슈_유형.getHierarchyLevel() != null) {
+            저장할_이슈_유형.setC_contents(이슈_유형.getHierarchyLevel().toString()); //Integer
+        }
 
         JiraIssueTypeEntity 저장된_이슈_유형 = jiraIssueType.addNode(저장할_이슈_유형);
 


### PR DESCRIPTION
…03.26

#close #time 1h +review SR @313devops

- 레드마인 서버에서 이슈 유형 조회시 etc, content 정보가 없어 null 체크

[ Backend-Core::Java-Service-Tree-Framework(JSTF)::chanho470 ] 요구 관리 : [Requirement Manage] http://www.a-rms.net
문서 관리 : [Document] http://www.313.co.kr/confluence 이슈 관리 : [IssueTracker] http://www.313.co.kr/jira
소스 관리 : [VersionControl] https://github.com/313devgrp 코드 리뷰 : [CodeReview] http://www.313.co.kr/fecru
빌드 관리 : [CICD-Deploy] http://www.313.co.kr/jenkins 배포 관리 : [Deploy-Pipeline] http://www.313.co.kr/spinnaker 아티 팩트 : [ArtifactManager] http://www.313.co.kr/nexus 코드 분석 : [CodeAnalysis] http://www.313.co.kr/sonar
성능 측정 : [ZipKin] http://www.313.co.kr/zipkin/

도커 관리 : [Docker Hub] https://hub.docker.com/u/313devgrp
클러스터1 : [Kubernetes] http://www.313.co.kr:31380
클러스터2 : [DockerSwarm] http://www.313.co.kr/portainer/#!/auth

디비 관리 : [DB Admin] http://www.313.co.kr/phpmyadmin/
오브 젝트 : [S3 Admin] http://www.313.co.kr/minio/login
캐시 관리 : [Cache Admin] http://www.313.co.kr/redis/
ELFK 스택1 : [NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices
ELFK 스택2 : [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true
ELFK 스택3 : [LogStash] http://www.313.co.kr/logstash/_node/stats?pretty
ELFK 스택4 : [Kibana] http://www.313.co.kr/kibana/app/home#/

모니터링 1 : [ElasticHQ] http://www.313.co.kr/elastichq/#!/
모니터링 2 : [Grafana] http://www.313.co.kr/grafana

인증 인가 : [Auth] http://www.313.co.kr/auth/

NFS 관리 : [NAS] http://www.313.co.kr:5000/webman/index.cgi
메일 관리 : [Mail] http://www.313.co.kr/mail/
원격 관리 : [RDP] http://www.313.co.kr/guacamole/#/