### PR TITLE
🙈 feat: [redmine-phm-84] #comment 분석메뉴 상단 상태 갯수 파악 관련 변경, DB 업데이트 - 24.08.16

### DIFF
--- a/src/main/java/com/arms/api/analysis/common/service/CommonServiceImpl.java
+++ b/src/main/java/com/arms/api/analysis/common/service/CommonServiceImpl.java
@@ -70,14 +70,20 @@ public class CommonServiceImpl implements CommonService {
                                 if (reqStateEntity == null) {
                                     return "null";
                                 }
-                                long stateId = entity.getReqStateEntity().getC_id();
-                                if (stateId == 10L) {
+
+                                // 고객사 상태의 매핑된 ARMS 상태 카테고리(열림, 진행중, 해결됨, 닫힘) 기준으로 계산하도록 변경
+                                if (entity.getReqStateEntity().getReqStateCategoryEntity() == null) {
+                                    return "null";
+                                }
+
+                                long categoryId = entity.getReqStateEntity().getReqStateCategoryEntity().getC_id();
+                                if (categoryId == 3L) {
                                     return "open";
-                                } else if (stateId == 11L) {
+                                } else if (categoryId == 4L) {
                                     return "in-progress";
-                                } else if (stateId == 12L) {
+                                } else if (categoryId == 5L) {
                                     return "resolved";
-                                } else if (stateId == 13L) {
+                                } else if (categoryId == 6L) {
                                     return "closed";
                                 } else {
                                     return "other";

--- a/src/main/java/com/arms/api/requirement/reqstate/model/ReqStateDTO.java
+++ b/src/main/java/com/arms/api/requirement/reqstate/model/ReqStateDTO.java
@@ -31,6 +31,9 @@ public class ReqStateDTO extends TreeBaseDTO {
     //비고
     private String c_etc;
 
+    // 기본 상태 여부
+    private String c_check;
+
     //상태 카테고리
     private Long c_state_category_mapping_id;
 

--- a/src/main/java/com/arms/api/requirement/reqstate/model/ReqStateEntity.java
+++ b/src/main/java/com/arms/api/requirement/reqstate/model/ReqStateEntity.java
@@ -61,6 +61,10 @@ public class ReqStateEntity extends TreeSearchEntity implements Serializable {
     @Column(name = "c_etc")
     private String c_etc;
 
+    // 기본 상태 여부
+    @Column(name = "c_check")
+    private String c_check;
+
     // 상태 카테고리 1:1 Row 단방향 연계
     private ReqStateCategoryEntity reqStateCategoryEntity;
 

--- a/src/main/resources/com/arms/db/V16__init_aRMS.sql
+++ b/src/main/resources/com/arms/db/V16__init_aRMS.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `aRMS`.`T_ARMS_REQSTATE`
+    ADD COLUMN c_check         text null comment '암스 기본 상태 설정 필드';
+
+Update `aRMS`.`T_ARMS_REQSTATE` set C_STATE_CATEGORY_MAPPING_ID = 3 Where C_ID = 10;
+Update `aRMS`.`T_ARMS_REQSTATE` set C_STATE_CATEGORY_MAPPING_ID = 4 Where C_ID = 11;
+Update `aRMS`.`T_ARMS_REQSTATE` set C_STATE_CATEGORY_MAPPING_ID = 5 Where C_ID = 12;
+Update `aRMS`.`T_ARMS_REQSTATE` set C_STATE_CATEGORY_MAPPING_ID = 6 Where C_ID = 13;
+
+Delete From `aRMS`.`T_ARMS_REQSTATE` Where C_ID IN (3, 4, 5, 6, 7, 8, 9);


### PR DESCRIPTION


1. 고객사 상태의 매핑된 ARMS 상태 카테고리(열림, 진행중, 해결됨, 닫힘) 기준으로 계산하도록 변경
2. 기존 상태(열림, 진행중, 해결됨, 닫힘) 제외 삭제 처리
3. 고객사의 기존 상태에 대한 카테고리 매핑 update
4. 상태 c_check(기본 상태 설정 여부) 컬럼 추가

#close #time 1h +review SR @313devops

추신 : 맨앞에 붙일 수 있는 구분
fix : Bug 류 처리 시 ( patch version up )
feat : 신규 기능 류 처리 시 ( minor version up )
perf : 메이저 기능 류 처리 시 ( major version up )

[ Backend-Core::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net/
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380/
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/