### PR TITLE
🙈 refactor: [redmine-phm-84] #comment 상태Entity 없는 reqAdd 데이터 이슈 대응 - 24.08.20

### DIFF
--- a/src/main/java/com/arms/api/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/arms/api/dashboard/service/DashboardServiceImpl.java
@@ -246,6 +246,10 @@ public class DashboardServiceImpl implements DashboardService {
             for(Long 요구사항_아이디 : 요구사항_아이디_목록) {
                 if (요구사항_아이디_상태_아이디_맵.containsKey(요구사항_아이디)) {
                     Long 상태_아이디 = 요구사항_아이디_상태_아이디_맵.get(요구사항_아이디);
+                    if (상태_아이디 == null) {
+                        continue;
+                    }
+
                     요구사항_상태별_개수_맵.put(상태_아이디, 요구사항_상태별_개수_맵.getOrDefault(상태_아이디,0L)+1);
                 }
             }
@@ -278,7 +282,10 @@ public class DashboardServiceImpl implements DashboardService {
         for(ReqAddEntity entity : 검색_결과_목록) {
             if(StringUtils.equals(entity.getC_type(),"default")) {
                 Long reqAddId = entity.getC_id();
-                Long stateId = Optional.ofNullable(entity.getReqStateEntity().getC_id()).orElse(null);
+                Long stateId = Optional.ofNullable(entity)
+                        .map(e -> e.getReqStateEntity())
+                        .map(e -> e.getC_id())
+                        .orElse(null);
                 요구사항_아이디_상태_맵.put(reqAddId,stateId);
             }
         }

--- a/src/main/java/com/arms/api/requirement/reqadd/model/ReqAddEntity.java
+++ b/src/main/java/com/arms/api/requirement/reqadd/model/ReqAddEntity.java
@@ -200,6 +200,7 @@ public class ReqAddEntity extends TreeSearchEntity implements Serializable {
     @LazyCollection(LazyCollectionOption.FALSE)
     @JsonManagedReference
     @OneToOne
+    @NotFound(action = NotFoundAction.IGNORE)
     @JoinColumn(name = "c_req_state_link", referencedColumnName = "c_id")
     public ReqStateEntity getReqStateEntity() { return reqStateEntity; }
 

--- a/src/main/java/com/arms/api/requirement/reqadd/service/ReqAddImpl.java
+++ b/src/main/java/com/arms/api/requirement/reqadd/service/ReqAddImpl.java
@@ -160,40 +160,37 @@ public class ReqAddImpl extends TreeServiceImpl implements ReqAdd {
 				.map(PdServiceVersionEntity::getC_title)
 				.collect(Collectors.joining(","));
 
-		if(followReqLinkDTO.getJiraProject()!=null){
-			JiraProjectEntity jiraProjectSearchEntity = new JiraProjectEntity();
-			jiraProjectSearchEntity.setC_id(followReqLinkDTO.getJiraProject());
-			JiraProjectEntity jiraProjectEntity = jiraProject.getNode(jiraProjectSearchEntity);
+		ReqAddDetailDTO.ReqAddDetailDTOBuilder reqAddDetailDTOBuilder = ReqAddDetailDTO.builder()
+															.pdService_c_title(pdServiceEntity.getC_title())
+															.pdServiceVersion_c_title(pdServiceVersionTitles)
+															.pdService_c_id(pdServiceEntity.getC_id())
+															.reqAdd_c_title(reqAddEntity.getC_title())
+															.reqAdd_c_req_writer(reqAddEntity.getC_req_writer())
+															.reqAdd_c_req_create_date(reqAddEntity.getC_req_create_date())
+															.reqAdd_c_req_reviewer01(reqAddEntity.getC_req_reviewer01())
+															.reqAdd_c_req_reviewer02(reqAddEntity.getC_req_reviewer02())
+															.reqAdd_c_req_reviewer03(reqAddEntity.getC_req_reviewer03())
+															.reqAdd_c_req_reviewer04(reqAddEntity.getC_req_reviewer04())
+															.reqAdd_c_req_reviewer05(reqAddEntity.getC_req_reviewer05())
+															.reqAdd_c_req_contents(reqAddEntity.getC_req_contents())
+															.reqAdd_c_req_start_date(reqAddEntity.getC_req_start_date())
+															.reqAdd_c_req_end_date(reqAddEntity.getC_req_end_date())
+															.c_drawio_contents(reqAddEntity.getC_drawio_contents())
+															.c_drawio_image_raw(reqAddEntity.getC_drawio_image_raw());
+
+		if (reqAddEntity.getReqStateEntity() != null && reqAddEntity.getReqStateEntity().getC_id() != null) {
+			reqAddDetailDTOBuilder.reqAdd_c_req_state_link(reqAddEntity.getReqStateEntity().getC_id());
 		}
 
-		if(followReqLinkDTO.getJiraServer()!=null) {
-			JiraServerEntity searchJiraServerEntity = new JiraServerEntity();
-			searchJiraServerEntity.setC_id(followReqLinkDTO.getJiraServer());
-			JiraServerEntity jiraServerEntity = jiraServer.getNode(searchJiraServerEntity);
+		if (reqAddEntity.getReqDifficultyEntity() != null && reqAddEntity.getReqDifficultyEntity().getC_id() != null) {
+			reqAddDetailDTOBuilder.reqAdd_c_req_difficulty_link(reqAddEntity.getReqDifficultyEntity().getC_id());
 		}
 
+		if (reqAddEntity.getReqPriorityEntity() != null && reqAddEntity.getReqPriorityEntity().getC_id() != null) {
+			reqAddDetailDTOBuilder.reqAdd_c_req_priority_link(reqAddEntity.getReqPriorityEntity().getC_id());
+		}
 
-		return ReqAddDetailDTO.builder()
-				.pdService_c_title(pdServiceEntity.getC_title())
-				.pdServiceVersion_c_title(pdServiceVersionTitles)
-				.pdService_c_id(pdServiceEntity.getC_id())
-				.reqAdd_c_title(reqAddEntity.getC_title())
-				.reqAdd_c_req_writer(reqAddEntity.getC_req_writer())
-				.reqAdd_c_req_create_date(reqAddEntity.getC_req_create_date())
-				.reqAdd_c_req_reviewer01(reqAddEntity.getC_req_reviewer01())
-				.reqAdd_c_req_reviewer02(reqAddEntity.getC_req_reviewer02())
-				.reqAdd_c_req_reviewer03(reqAddEntity.getC_req_reviewer03())
-				.reqAdd_c_req_reviewer04(reqAddEntity.getC_req_reviewer04())
-				.reqAdd_c_req_reviewer05(reqAddEntity.getC_req_reviewer05())
-				.reqAdd_c_req_contents(reqAddEntity.getC_req_contents())
-				.reqAdd_c_req_state_link(reqAddEntity.getReqStateEntity().getC_id())
-				.reqAdd_c_req_difficulty_link(reqAddEntity.getReqDifficultyEntity().getC_id())
-				.reqAdd_c_req_priority_link(reqAddEntity.getReqPriorityEntity().getC_id())
-				.reqAdd_c_req_start_date(reqAddEntity.getC_req_start_date())
-				.reqAdd_c_req_end_date(reqAddEntity.getC_req_end_date())
-				.c_drawio_contents(reqAddEntity.getC_drawio_contents())
-				.c_drawio_image_raw(reqAddEntity.getC_drawio_image_raw())
-				.build();
+		return reqAddDetailDTOBuilder.build();
 	}
 
 	@Override

--- a/src/main/java/com/arms/api/requirement/reqadd_state_pure/model/ReqAddStatePureEntity.java
+++ b/src/main/java/com/arms/api/requirement/reqadd_state_pure/model/ReqAddStatePureEntity.java
@@ -55,6 +55,7 @@ public class ReqAddStatePureEntity extends TreeSearchEntity implements Serializa
     @LazyCollection(LazyCollectionOption.FALSE)
     @JsonManagedReference
     @OneToOne
+    @NotFound(action = NotFoundAction.IGNORE)
     @JoinColumn(name = "c_req_state_link", referencedColumnName = "c_id")
     public ReqStateEntity getReqStateEntity() { return reqStateEntity; }
 


### PR DESCRIPTION

1. 연결된 reqEntity가 없을 경우 무시 처리
2. 디테일 조회 시 builder 패턴 null 처리
3. 대쉬보드 인력별_요구사항_상태_누적_TOP5 API null 처리 추가

#close #time 1h +review SR @313devops

추신 : 맨앞에 붙일 수 있는 구분
fix : Bug 류 처리 시 ( patch version up )
feat : 신규 기능 류 처리 시 ( minor version up )
perf : 메이저 기능 류 처리 시 ( major version up )

[ Backend-Core::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net/
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380/
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/